### PR TITLE
Add pick auto-grader (final box-score → W/L)

### DIFF
--- a/app/api/main.py
+++ b/app/api/main.py
@@ -536,6 +536,78 @@ def delete_pick(pick_id: str):
     return {"deleted": pick_id}
 
 
+@app.post("/api/picks/{pick_id}/auto-grade")
+def auto_grade_pick(pick_id: str):
+    """Settle a pick against the final ESPN box score for its game_id.
+
+    Returns the per-leg outcome + overall status, and updates the pick
+    in place. If the game isn't final yet, status stays 'open' but
+    we still return the projected grade so the user sees a preview.
+    """
+    from app.data.pick_grader import fetch_and_grade
+    from app.data.pick_log import PickStore
+
+    store = PickStore()
+    pick = store.get(pick_id)
+    if pick is None:
+        return JSONResponse({"error": "Pick not found"}, status_code=404)
+    if not pick.get("game_id"):
+        return JSONResponse({"error": "Pick has no game_id — cannot auto-grade"}, status_code=400)
+
+    grade = fetch_and_grade(pick)
+    if grade is None:
+        return JSONResponse({"error": "Could not fetch box score"}, status_code=502)
+
+    payload = {
+        "pick_id": pick_id,
+        "overall": grade.overall,
+        "game_final": grade.game_final,
+        "box_score": grade.box_score,
+        "legs": [
+            {
+                "description": l.description,
+                "player": l.player,
+                "stat": l.stat,
+                "side": l.side,
+                "line": l.line,
+                "actual": l.actual,
+                "status": l.status,
+                "note": l.note,
+            } for l in grade.legs
+        ],
+    }
+    if grade.game_final:
+        store.update_status(pick_id, grade.overall)
+        payload["committed"] = True
+    else:
+        payload["committed"] = False
+        payload["note"] = "Game not final yet — preview only, status unchanged"
+    return payload
+
+
+@app.post("/api/picks/grade-pending")
+def grade_pending_picks():
+    """Try to auto-grade every open pick with a game_id."""
+    from app.data.pick_grader import fetch_and_grade
+    from app.data.pick_log import PickStore
+
+    store = PickStore()
+    results = []
+    for pick in store.all():
+        if pick.get("status") != "open" or not pick.get("game_id"):
+            continue
+        grade = fetch_and_grade(pick)
+        if grade is None or not grade.game_final:
+            continue
+        store.update_status(pick["id"], grade.overall)
+        results.append({
+            "pick_id": pick["id"],
+            "overall": grade.overall,
+            "box_score": grade.box_score,
+        })
+    return {"graded": len(results), "results": results}
+
+
 # ---------- ChatGPT-friendly endpoints ----------
 
 @app.get("/api/top-picks")

--- a/app/data/pick_grader.py
+++ b/app/data/pick_grader.py
@@ -1,0 +1,182 @@
+"""Auto-grader — settle a Claude pick against the final ESPN box score.
+
+Given a pick's `game_id` and its legs (player + stat + side + line), this
+fetches the final NBA box from ESPN, looks up each player's stat, and
+returns the leg outcomes (won/lost/push) plus an overall pick status.
+
+Player-name matching is case-insensitive and tolerates "Last" / "F. Last"
+forms (handy for parsed bet365 slips that abbreviate first names).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from app.data.live_boxscore import NBABoxGame, NBABoxPlayer, fetch_nba_boxscore
+
+log = logging.getLogger(__name__)
+
+
+COMBO_STATS = {
+    "pra": ("points", "rebounds", "assists"),
+    "pr":  ("points", "rebounds"),
+    "pa":  ("points", "assists"),
+    "ra":  ("rebounds", "assists"),
+}
+
+
+def _stat_value(p: NBABoxPlayer, stat: str) -> float | None:
+    """Return the player's value for `stat`, summing components for combo stats."""
+    if stat in COMBO_STATS:
+        return float(sum(getattr(p, c, 0) for c in COMBO_STATS[stat]))
+    if hasattr(p, stat):
+        return float(getattr(p, stat))
+    aliases = {
+        "threes": "threes_made", "3pm": "threes_made", "3s": "threes_made",
+        "stl": "steals", "blk": "blocks",
+        "pts": "points", "reb": "rebounds", "ast": "assists",
+    }
+    s = aliases.get(stat.lower())
+    return float(getattr(p, s)) if s and hasattr(p, s) else None
+
+
+def _normalize_name(name: str) -> str:
+    return re.sub(r"[^a-z]", "", (name or "").lower())
+
+
+def _find_player(box: NBABoxGame, name: str) -> NBABoxPlayer | None:
+    """Match by full name first, then by last name, then by initial+last."""
+    n = _normalize_name(name)
+    if not n:
+        return None
+    # Exact normalized match
+    for p in box.players:
+        if _normalize_name(p.player) == n:
+            return p
+    # Last-name only
+    parts = name.split()
+    if not parts:
+        return None
+    last = _normalize_name(parts[-1])
+    candidates = [p for p in box.players if _normalize_name(p.player).endswith(last)]
+    if len(candidates) == 1:
+        return candidates[0]
+    # First-initial + last (e.g. "K.Johnson" → matches "Keldon Johnson")
+    if len(parts) >= 2 and len(parts[0]) <= 2:
+        first_initial = _normalize_name(parts[0])[:1]
+        narrowed = [
+            p for p in candidates
+            if _normalize_name(p.player).startswith(first_initial)
+        ]
+        if len(narrowed) == 1:
+            return narrowed[0]
+    return None
+
+
+@dataclass
+class LegOutcome:
+    description: str
+    player: str
+    stat: str
+    side: str
+    line: float | None
+    actual: float | None
+    status: str             # "won" | "lost" | "push" | "void"
+    note: str = ""
+
+
+@dataclass
+class PickGrade:
+    pick_id: str
+    overall: str            # "won" | "lost" | "push" | "void"
+    legs: list[LegOutcome]
+    game_final: bool
+    box_score: str          # short summary like "MIN 114, SAS 109"
+
+
+def grade_leg(leg: dict, box: NBABoxGame) -> LegOutcome:
+    desc = leg.get("description", "")
+    player = leg.get("player", "") or ""
+    stat = (leg.get("stat", "") or "").lower()
+    side = (leg.get("side", "") or "").upper()
+    line = leg.get("line")
+
+    if not player or not stat or line is None or side not in ("OVER", "UNDER"):
+        return LegOutcome(
+            description=desc, player=player, stat=stat, side=side,
+            line=line, actual=None, status="void",
+            note="Leg is missing structured fields (player/stat/side/line)",
+        )
+
+    found = _find_player(box, player)
+    if found is None:
+        return LegOutcome(
+            description=desc, player=player, stat=stat, side=side,
+            line=line, actual=None, status="void",
+            note=f"Could not find {player} in box score",
+        )
+
+    actual = _stat_value(found, stat)
+    if actual is None:
+        return LegOutcome(
+            description=desc, player=player, stat=stat, side=side,
+            line=line, actual=None, status="void",
+            note=f"Stat '{stat}' not recognized",
+        )
+
+    line_f = float(line)
+    if actual == line_f:
+        status = "push"
+    elif (side == "OVER" and actual > line_f) or (side == "UNDER" and actual < line_f):
+        status = "won"
+    else:
+        status = "lost"
+
+    return LegOutcome(
+        description=desc, player=found.player, stat=stat, side=side,
+        line=line_f, actual=actual, status=status,
+    )
+
+
+def grade_pick(pick: dict, box: NBABoxGame) -> PickGrade:
+    """Grade a Pick dict against a final NBABoxGame.
+
+    Parlay rules: any leg LOST → pick LOST. All WON → pick WON.
+    Any leg PUSH (with rest won) → pick WON at reduced odds, but we
+    simplify to PUSH for the parlay's status; the user can manually
+    override if their book pushes the leg out of the parlay.
+    Any leg VOID → return overall VOID with a note (manual review).
+    """
+    leg_outcomes = [grade_leg(l, box) for l in (pick.get("legs") or [])]
+
+    if any(l.status == "void" for l in leg_outcomes):
+        overall = "void"
+    elif any(l.status == "lost" for l in leg_outcomes):
+        overall = "lost"
+    elif any(l.status == "push" for l in leg_outcomes):
+        overall = "push"
+    else:
+        overall = "won"
+
+    score = f"{box.away_team} {box.away_score}, {box.home_team} {box.home_score}"
+    return PickGrade(
+        pick_id=pick.get("id", ""),
+        overall=overall,
+        legs=leg_outcomes,
+        game_final=box.is_final,
+        box_score=score,
+    )
+
+
+def fetch_and_grade(pick: dict) -> PickGrade | None:
+    """One-shot: fetch the box, grade. Returns None if the box can't be fetched."""
+    game_id = pick.get("game_id") or ""
+    if not game_id:
+        return None
+    box = fetch_nba_boxscore(game_id)
+    if box is None:
+        return None
+    return grade_pick(pick, box)

--- a/app/web/app.js
+++ b/app/web/app.js
@@ -379,6 +379,19 @@ async function loadPicks() {
   }
 }
 
+async function gradeAllPending() {
+  toast("Grading all pending picks...");
+  try {
+    const r = await fetch("/api/picks/grade-pending", { method: "POST" });
+    const d = await r.json();
+    if (d.error) { toast(d.error, "error"); return; }
+    toast(`Graded ${d.graded} pick${d.graded === 1 ? "" : "s"}`, "success");
+    loadPicks();
+  } catch (e) { toast("Grade-all failed", "error"); }
+}
+
+document.getElementById("grade-all-btn").addEventListener("click", gradeAllPending);
+
 function renderPickSummary(s) {
   const roiColor = s.pnl >= 0 ? "var(--green)" : "var(--red)";
   const calColor = Math.abs(s.calibration_gap) < 0.05 ? "var(--green)" : Math.abs(s.calibration_gap) < 0.15 ? "var(--yellow)" : "var(--red)";
@@ -416,6 +429,9 @@ function renderPickList(picks) {
     const promoteBtn = p.promoted_to_bet_id
       ? `<span class="promoted-tag">Promoted ✓</span>`
       : `<button class="btn btn-sm btn-primary" onclick="promotePick('${p.id}')">Place this</button>`;
+    const autoGradeBtn = (p.status === "open" && p.game_id)
+      ? `<button class="btn btn-sm btn-outline" onclick="autoGradePick('${p.id}')">Auto-grade</button>`
+      : "";
     return `
       <div class="bet-card status-${statusClass}">
         <div class="bet-head">
@@ -435,6 +451,7 @@ function renderPickList(picks) {
         </div>
         <div class="bet-actions">
           ${settleBtns}
+          ${autoGradeBtn}
           ${promoteBtn}
           <button class="btn btn-sm btn-danger" onclick="deletePick('${p.id}')">Delete</button>
         </div>
@@ -470,6 +487,25 @@ async function promotePick(id) {
     toast("Placed in My Bets", "success");
     loadPicks();
   } catch (e) { toast("Promote failed", "error"); }
+}
+
+async function autoGradePick(id) {
+  toast("Grading from final box score...");
+  try {
+    const r = await fetch(`/api/picks/${id}/auto-grade`, { method: "POST" });
+    const d = await r.json();
+    if (d.error) { toast(d.error, "error"); return; }
+    if (d.committed) {
+      const legSummary = d.legs.map(l =>
+        `${l.player} ${l.side} ${l.line} ${l.stat}: ${l.actual ?? "?"} → ${l.status.toUpperCase()}`
+      ).join("\n");
+      toast(`Pick ${d.overall.toUpperCase()} · ${d.box_score}`, d.overall === "won" ? "success" : "error");
+      alert(`${d.box_score}\n\n${legSummary}\n\nOverall: ${d.overall.toUpperCase()}`);
+    } else {
+      toast(d.note || "Game not final yet", "default");
+    }
+    loadPicks();
+  } catch (e) { toast("Auto-grade failed", "error"); }
 }
 
 async function deletePick(id) {

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -61,6 +61,7 @@
     <div class="panel-header">
       <h2>Claude's Picks</h2>
       <span class="panel-sub">Auto-logged when I suggest a parlay · graded at $1 flat</span>
+      <button id="grade-all-btn" class="btn btn-sm btn-outline">Grade all pending</button>
     </div>
     <div id="picks-summary"></div>
     <div id="picks-list" class="bets-list"></div>


### PR DESCRIPTION
Adds an auto-grader so the pick log settles itself the moment a game ends — no more manually tapping Won/Lost. Same PR-merge workaround for the sandbox 403.

## What's new
- `app/data/pick_grader.py` — given a pick's `game_id`, fetches the final ESPN summary, looks up each player's stat (with fuzzy name matching that tolerates `K.Johnson` etc.), grades each leg vs. its line, and rolls them up to a parlay outcome
- Combo stats handled (`pra`, `pr`, `pa`, `ra` — sum of components)
- Ambiguous name matches safely VOID (e.g. "Johnson" with two Johnsons in the box)
- `POST /api/picks/{id}/auto-grade` — one pick
- `POST /api/picks/grade-pending` — every open pick whose game is final
- Frontend: "Auto-grade" button per pick + "Grade all pending" at top of the Claude Picks tab

Parlay rules: all WON → WON; any LOST → LOST; any PUSH (rest WON) → PUSH; any VOID → VOID for manual review.

55 tests still pass. Endpoints smoke-tested via FastAPI's TestClient.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CwoLj4NSh1kHwWh2buFzvz)_