### PR TITLE
Add balldontlie.io as backup NBA box-score source

### DIFF
--- a/app/api/main.py
+++ b/app/api/main.py
@@ -464,6 +464,9 @@ def add_pick(body: dict = Body(...)):
             rationale=body.get("rationale", ""),
             confidence=body.get("confidence", "medium"),
             game_id=body.get("game_id", ""),
+            game_date=body.get("game_date", ""),
+            home_team=body.get("home_team", ""),
+            away_team=body.get("away_team", ""),
             source=body.get("source", "claude"),
         )
     except (KeyError, ValueError, TypeError) as e:
@@ -551,8 +554,13 @@ def auto_grade_pick(pick_id: str):
     pick = store.get(pick_id)
     if pick is None:
         return JSONResponse({"error": "Pick not found"}, status_code=404)
-    if not pick.get("game_id"):
-        return JSONResponse({"error": "Pick has no game_id — cannot auto-grade"}, status_code=400)
+    has_espn = bool(pick.get("game_id"))
+    has_fallback = all(pick.get(k) for k in ("game_date", "home_team", "away_team"))
+    if not has_espn and not has_fallback:
+        return JSONResponse(
+            {"error": "Pick has no game_id or (game_date, home_team, away_team) — cannot auto-grade"},
+            status_code=400,
+        )
 
     grade = fetch_and_grade(pick)
     if grade is None:
@@ -594,7 +602,11 @@ def grade_pending_picks():
     store = PickStore()
     results = []
     for pick in store.all():
-        if pick.get("status") != "open" or not pick.get("game_id"):
+        if pick.get("status") != "open":
+            continue
+        has_espn = bool(pick.get("game_id"))
+        has_fallback = all(pick.get(k) for k in ("game_date", "home_team", "away_team"))
+        if not has_espn and not has_fallback:
             continue
         grade = fetch_and_grade(pick)
         if grade is None or not grade.game_final:
@@ -754,6 +766,7 @@ def status():
     return {
         "halftime_provider": "espn",
         "vision_enabled": bool(os.environ.get("ANTHROPIC_API_KEY", "").strip()),
+        "balldontlie_enabled": bool(os.environ.get("BALLDONTLIE_API_KEY", "").strip()),
     }
 
 

--- a/app/data/balldontlie.py
+++ b/app/data/balldontlie.py
@@ -1,0 +1,185 @@
+"""balldontlie.io NBA data source.
+
+Free public API used as a backup to ESPN. Auth via the BALLDONTLIE_API_KEY
+env var. Their game IDs differ from ESPN's, so we look up games by
+(date, home_abbr, away_abbr) then pull the per-player stats for that game.
+
+Returns the same NBABoxGame shape `live_boxscore` produces so the
+auto-grader and any consumer code is source-agnostic.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+import httpx
+
+from app.data.live_boxscore import NBABoxGame, NBABoxPlayer
+
+log = logging.getLogger(__name__)
+
+BASE = "https://api.balldontlie.io/v1"
+
+
+def _headers() -> dict[str, str] | None:
+    key = os.environ.get("BALLDONTLIE_API_KEY", "").strip()
+    if not key:
+        return None
+    return {"Authorization": key}
+
+
+def _team_abbr(team: dict[str, Any]) -> str:
+    return (team.get("abbreviation") or team.get("triCode") or "").upper()
+
+
+def _find_game_id(
+    date: str,
+    home_abbr: str,
+    away_abbr: str,
+    timeout: float = 8.0,
+) -> int | None:
+    """Look up the balldontlie game_id for a given (date, home, away).
+
+    `date` should be YYYY-MM-DD. Returns None if not found / network fails.
+    """
+    headers = _headers()
+    if headers is None:
+        return None
+    try:
+        with httpx.Client(timeout=timeout) as client:
+            r = client.get(
+                f"{BASE}/games",
+                params={"dates[]": date, "per_page": 100},
+                headers=headers,
+            )
+            r.raise_for_status()
+            data = r.json()
+    except httpx.HTTPError as e:
+        log.warning("balldontlie games fetch failed (%s): %s", date, e)
+        return None
+
+    home_u = home_abbr.upper()
+    away_u = away_abbr.upper()
+    for g in data.get("data", []):
+        gh = _team_abbr(g.get("home_team", {}))
+        ga = _team_abbr(g.get("visitor_team", {}))
+        if (gh == home_u and ga == away_u) or (gh == away_u and ga == home_u):
+            return int(g["id"])
+    return None
+
+
+def fetch_final_box_by_date_teams(
+    date: str,
+    home_abbr: str,
+    away_abbr: str,
+    espn_game_id: str = "",
+    timeout: float = 10.0,
+) -> NBABoxGame | None:
+    """Fetch a final box from balldontlie by (date, home, away).
+
+    `espn_game_id` is optional metadata stamped on the returned NBABoxGame
+    so callers that already pass an ESPN id around can keep doing so.
+    """
+    bdl_id = _find_game_id(date, home_abbr, away_abbr, timeout=timeout)
+    if bdl_id is None:
+        return None
+
+    headers = _headers()
+    if headers is None:
+        return None
+
+    try:
+        with httpx.Client(timeout=timeout) as client:
+            r = client.get(
+                f"{BASE}/stats",
+                params={"game_ids[]": bdl_id, "per_page": 100},
+                headers=headers,
+            )
+            r.raise_for_status()
+            data = r.json()
+            # Also pull the game itself for the score / status fields
+            rg = client.get(f"{BASE}/games/{bdl_id}", headers=headers)
+            rg.raise_for_status()
+            game = rg.json().get("data", rg.json())
+    except httpx.HTTPError as e:
+        log.warning("balldontlie stats fetch failed (game %s): %s", bdl_id, e)
+        return None
+
+    return _parse_box(data.get("data", []), game, espn_game_id=espn_game_id)
+
+
+def _parse_min(m: Any) -> float:
+    """balldontlie returns minutes as a string like '34' or '34:12'."""
+    if m is None:
+        return 0.0
+    if isinstance(m, (int, float)):
+        return float(m)
+    s = str(m).strip()
+    if not s:
+        return 0.0
+    if ":" in s:
+        mm, ss = s.split(":", 1)
+        try:
+            return float(mm) + float(ss) / 60.0
+        except ValueError:
+            return 0.0
+    try:
+        return float(s)
+    except ValueError:
+        return 0.0
+
+
+def _parse_box(stats: list[dict], game: dict, espn_game_id: str = "") -> NBABoxGame:
+    home = game.get("home_team", {})
+    away = game.get("visitor_team", {})
+    home_abbr = _team_abbr(home)
+    away_abbr = _team_abbr(away)
+
+    players: list[NBABoxPlayer] = []
+    for s in stats:
+        p = s.get("player", {})
+        t = s.get("team", {})
+        first = p.get("first_name", "")
+        last = p.get("last_name", "")
+        full = f"{first} {last}".strip()
+        players.append(NBABoxPlayer(
+            player=full,
+            team=_team_abbr(t),
+            starter=bool(s.get("starter", False)),
+            minutes=_parse_min(s.get("min")),
+            points=int(s.get("pts") or 0),
+            rebounds=int(s.get("reb") or 0),
+            assists=int(s.get("ast") or 0),
+            threes_made=int(s.get("fg3m") or 0),
+            steals=int(s.get("stl") or 0),
+            blocks=int(s.get("blk") or 0),
+            turnovers=int(s.get("turnover") or 0),
+            fouls=int(s.get("pf") or 0),
+            fg_made=int(s.get("fgm") or 0),
+            fg_att=int(s.get("fga") or 0),
+            ft_made=int(s.get("ftm") or 0),
+            ft_att=int(s.get("fta") or 0),
+        ))
+
+    status = (game.get("status") or "").lower()
+    is_final = "final" in status or game.get("period", 0) >= 4 and not status.startswith("q")
+    period = int(game.get("period") or 4)
+
+    return NBABoxGame(
+        game_id=espn_game_id or str(game.get("id", "")),
+        home_team=home_abbr,
+        away_team=away_abbr,
+        home_team_name=home.get("full_name", home_abbr),
+        away_team_name=away.get("full_name", away_abbr),
+        home_score=int(game.get("home_team_score") or 0),
+        away_score=int(game.get("visitor_team_score") or 0),
+        quarter=period,
+        clock="0:00" if is_final else (game.get("time") or ""),
+        is_halftime=False,
+        is_final=is_final,
+        home_quarters=[],
+        away_quarters=[],
+        players=players,
+    )

--- a/app/data/box_score.py
+++ b/app/data/box_score.py
@@ -1,0 +1,52 @@
+"""Source-agnostic final box-score fetcher.
+
+Tries providers in order:
+  1. ESPN summary endpoint (works for any game with an ESPN id)
+  2. balldontlie.io (free, key required, looked up by date + teams)
+
+The grader and any future consumer should call `fetch_final_box(...)`
+rather than ESPN or balldontlie directly — that way new sources slot
+in here without touching consumer code.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from app.data.balldontlie import fetch_final_box_by_date_teams
+from app.data.live_boxscore import NBABoxGame, fetch_nba_boxscore
+
+log = logging.getLogger(__name__)
+
+
+def fetch_final_box(
+    espn_game_id: str | None = None,
+    *,
+    game_date: str | None = None,
+    home_team: str | None = None,
+    away_team: str | None = None,
+) -> NBABoxGame | None:
+    """Fetch the final box from whichever source is available.
+
+    At least one of these must be passable:
+      - `espn_game_id` (e.g. '401871155')
+      - or a complete (game_date, home_team, away_team) triple for the
+        balldontlie fallback. `game_date` is YYYY-MM-DD.
+
+    Returns None only when every source fails or no identifiers are provided.
+    """
+    if espn_game_id:
+        box = fetch_nba_boxscore(espn_game_id)
+        if box is not None:
+            return box
+        log.info("ESPN had no box for %s — trying balldontlie", espn_game_id)
+
+    if game_date and home_team and away_team:
+        return fetch_final_box_by_date_teams(
+            date=game_date,
+            home_abbr=home_team,
+            away_abbr=away_team,
+            espn_game_id=espn_game_id or "",
+        )
+
+    return None

--- a/app/data/pick_grader.py
+++ b/app/data/pick_grader.py
@@ -15,7 +15,8 @@ import re
 from dataclasses import dataclass
 from typing import Any
 
-from app.data.live_boxscore import NBABoxGame, NBABoxPlayer, fetch_nba_boxscore
+from app.data.box_score import fetch_final_box
+from app.data.live_boxscore import NBABoxGame, NBABoxPlayer
 
 log = logging.getLogger(__name__)
 
@@ -172,11 +173,17 @@ def grade_pick(pick: dict, box: NBABoxGame) -> PickGrade:
 
 
 def fetch_and_grade(pick: dict) -> PickGrade | None:
-    """One-shot: fetch the box, grade. Returns None if the box can't be fetched."""
-    game_id = pick.get("game_id") or ""
-    if not game_id:
-        return None
-    box = fetch_nba_boxscore(game_id)
+    """One-shot: fetch the box (from any available source), grade.
+
+    Uses `game_id` first (ESPN), falls back to (`game_date`, `home_team`,
+    `away_team`) via balldontlie. Returns None only if every source fails.
+    """
+    box = fetch_final_box(
+        espn_game_id=pick.get("game_id") or None,
+        game_date=pick.get("game_date") or None,
+        home_team=pick.get("home_team") or None,
+        away_team=pick.get("away_team") or None,
+    )
     if box is None:
         return None
     return grade_pick(pick, box)

--- a/app/data/pick_log.py
+++ b/app/data/pick_log.py
@@ -44,7 +44,10 @@ class Pick:
     id: str
     suggested_at: float
     sport: str                       # "nba" | "mlb" | "other"
-    game_id: str = ""
+    game_id: str = ""                # ESPN id (preferred — works with ESPN summary)
+    game_date: str = ""              # YYYY-MM-DD (enables balldontlie fallback)
+    home_team: str = ""              # team abbr (e.g. "MIN") — for fallback lookup
+    away_team: str = ""              # team abbr (e.g. "SAS") — for fallback lookup
     confidence: str = "medium"       # "low" | "medium" | "high"
     legs: list[PickLeg] = field(default_factory=list)
     american_odds: int | None = None      # combined parlay odds
@@ -209,6 +212,9 @@ def make_pick(
     rationale: str = "",
     confidence: str = "medium",
     game_id: str = "",
+    game_date: str = "",
+    home_team: str = "",
+    away_team: str = "",
     source: str = "claude",
 ) -> Pick:
     """Build a Pick — `decimal_odds` is derived from american_odds if not given."""
@@ -218,6 +224,9 @@ def make_pick(
         suggested_at=time.time(),
         sport=sport,
         game_id=game_id,
+        game_date=game_date,
+        home_team=(home_team or "").upper(),
+        away_team=(away_team or "").upper(),
         confidence=confidence,
         legs=legs,
         american_odds=american_odds,

--- a/app/web/app.js
+++ b/app/web/app.js
@@ -429,7 +429,8 @@ function renderPickList(picks) {
     const promoteBtn = p.promoted_to_bet_id
       ? `<span class="promoted-tag">Promoted ✓</span>`
       : `<button class="btn btn-sm btn-primary" onclick="promotePick('${p.id}')">Place this</button>`;
-    const autoGradeBtn = (p.status === "open" && p.game_id)
+    const canAutoGrade = p.status === "open" && (p.game_id || (p.game_date && p.home_team && p.away_team));
+    const autoGradeBtn = canAutoGrade
       ? `<button class="btn btn-sm btn-outline" onclick="autoGradePick('${p.id}')">Auto-grade</button>`
       : "";
     return `


### PR DESCRIPTION
Pairs the system with balldontlie.io as a free open NBA data backup so the grader is never single-sourced on ESPN.

## What's new
- `app/data/balldontlie.py` — fetches games by date + teams, pulls per-player stats, normalizes to the same `NBABoxGame` shape the app already uses
- `app/data/box_score.py` — `fetch_final_box(...)` tries ESPN first, then balldontlie. Consumer code calls this instead of either source directly
- Auto-grader accepts `(game_date, home_team, away_team)` on a pick as a fallback identifier; the `/api/picks` POST threads those fields through
- Frontend shows the Auto-grade button as long as **either** an ESPN `game_id` **or** the date+teams triple is present
- `/api/status` exposes `balldontlie_enabled`

## Setup
1. Get a free key at balldontlie.io (registration → API key in dashboard)
2. Set `BALLDONTLIE_API_KEY=<key>` in your Railway env vars
3. Redeploy — `/api/status` will now show `"balldontlie_enabled": true`

## Tests
55 pytest passing + a mocked end-to-end fallback flow grades a 4-leg SAS/MIN parlay correctly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CwoLj4NSh1kHwWh2buFzvz)_