### PR TITLE
Add low-touches confidence dampener (CLE/DET G5 retrospective)

### DIFF
--- a/app/sports/halftime_projection.py
+++ b/app/sports/halftime_projection.py
@@ -205,6 +205,21 @@ def project_nba_halftime(game: NBABoxGame) -> HalftimeGame:
                     # Light 1H minutes = bench → garbage-time burn
                     second_half_mean *= 1.20
 
+            # Low-touches confidence dampener — added 2026-05-13 after the
+            # CLE/DET G5 retrospective: LeVert went 2-2 FG in 13 1H minutes
+            # for 7 pts, then 0-5 in 2H for 0 pts. His 1H "rate" was 2 made
+            # shots, not a stable signal. The mean projection was reasonable
+            # but the confidence was inflated. When 1H FGA/min is well below
+            # typical rotation usage (~0.5), widen the SD so a real edge is
+            # still flagged but the model doesn't over-rank these players.
+            fga_per_min = (p.fg_att / p.minutes) if p.minutes > 0 else 0.0
+            if (
+                p.minutes >= 10
+                and fga_per_min < 0.30
+                and stat in ("points", "threes_made", "pra", "pr", "pa")
+            ):
+                second_half_sd *= 1.4
+
             second_half_mean = max(0.0, second_half_mean)
             second_half_sd = max(0.4, second_half_sd)
 


### PR DESCRIPTION
Post-game fix from tonight's CLE/DET G5 retrospective.

## The miss
LeVert went 2-2 FG in 13 1H minutes for 7 pts. Model projected ~14.6 total (line 10.5), ranked him #2 in top edges. He scored 0 in 2H on 0-5 shooting. Bet lost.

The **mean was defensible** — his season rate puts him ~14 pts. The miss was *variance*, but the model's **confidence was inflated** because the 1H "rate" came from only 2 made shots.

## The fix
SD inflation when 1H FGA/min < 0.30 (well below typical NBA rotation ~0.5):
- Mean projection **unchanged** — real edges stay real
- SD widens **1.4×** — the simulator's p_over drops, the leg ranks lower in top-edge lists, and it carries less weight in correlated parlay math

Applies only to scoring stats (points, threes_made, pra, pr, pa). Rebounds/assists don't scale with FGA so they're untouched.

## Verified on the actual G5 box
| Player | 1H FGA/min | Triggers? | Baseline SD → Adjusted SD |
|---|---|---|---|
| LeVert | 0.15 | ✅ | 3.0 → 4.23 |
| Strus | 0.40 | — | 2.33 (unchanged) |
| Cade | 0.70 | — | 3.11 (unchanged) |

55 tests pass. The CLE/DET parlay that hit tonight (Parlay 2: Strus + Harden + Allen + Mitchell UNDER) would still cash with this change — none of those legs trigger the dampener. Only LeVert's confidence drops, which is correct in hindsight.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CwoLj4NSh1kHwWh2buFzvz)_